### PR TITLE
Use tt-volcanoes website image

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Code: [https://github.com/MHenderson/tt-beach-volleyball](https://github.com/MHe
 
 ### 20: Volcano Eruptions
 
-Code: [https://github.com/MHenderson/tt-volcano-eruptions](https://github.com/MHenderson/tt-volcano-eruptions)
+Code: [https://github.com/MHenderson/tt-volcanoes](https://github.com/MHenderson/tt-volcanoes)
 
-![](img/eruptions.png)
+![](https://mhenderson.github.io/tt-volcanoes/img/eruptions.png)
 
 ## 2019
 


### PR DESCRIPTION
Instead of hosting a copy of the image in this repo we can publish a website with Github Pages and link directly to the image from there instead.